### PR TITLE
Fix build warnings and errors on nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,20 +4,18 @@
 name = "ecspy"
 version = "0.1.0"
 dependencies = [
- "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_hwio 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "redox_hwio",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
 
 [[package]]
 name = "redox_hwio"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[metadata]
-"checksum libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
-"checksum redox_hwio 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "41aa2c4c67329a04106644cad336238aa5adecfd73d06fb10339d472ce6d8070"
+checksum = "2b3b8075af56e2600f1bc43e97cb3911b8320d89d39a6215739c3cfff91af016"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libc = "0.2.80"
-redox_hwio = "0.1.3"
+libc = "0.2"
+redox_hwio = "0.1.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,7 @@ use hwio::{Io, Pio};
 use std::io;
 
 fn main() {
-    if unsafe { libc::iopl(3) } != 0 {
-        panic!("iopl: {}", io::Error::last_os_error());
-    }
+    assert!(unsafe { libc::iopl(3) } == 0, "iopl: {}", io::Error::last_os_error());
 
     let addr_port = || -> Pio<u8> {
         Pio::<u8>::new(0x2E)
@@ -40,6 +38,7 @@ fn main() {
         d2_read(0x12)
     };
 
+    #[allow(unused_variables)]
     let i2ec_write = |addr: u16, value: u8| {
         d2_write(0x11, (addr >> 8) as u8);
         d2_write(0x10, addr as u8);


### PR DESCRIPTION
Update redox_hwio to fix building dependencies on nightly.

Fix warnings:
- clippy::if_then_panic

Silence warnings:
- unused_variables